### PR TITLE
24.2.1 PCR360-11526 Temp files should only be created in /tmp when APP_TEMP_DIR is undefined

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "pcr/zf1-extras-future",
-    "description": "Zend Framework 1 Extras PHP 7.2 and 7.3 compatible",
+    "description": "Zend Framework 1 Extras The aim is to keep ZF1 Extras working with the latest PHP versions",
     "type": "library",
-    "version": "24.2.0",
+    "version": "24.2.1",
     "keywords": [
         "framework",
         "zf1"
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.2.11",
-        "pcr/zf1-future": "^24.2.0"
+        "pcr/zf1-future": "^24.2.2"
     },
     "autoload": {
         "psr-0": {
@@ -33,8 +33,7 @@
     ],
     "extra": {
         "branch-alias": {
-            "dev-master": "1.12.x-dev",
-            "dev-PCR360-11213-PHP8.3-support": "24.2.x-dev"
+            "dev-master": "1.12.x-dev"
         }
     },
     "replace": {

--- a/library/ZendX/Console/Process/Unix.php
+++ b/library/ZendX/Console/Process/Unix.php
@@ -610,7 +610,11 @@ abstract class ZendX_Console_Process_Unix
      */
     private function _createIpcSegment()
     {
-        $this->_ipcSegFile = realpath(sys_get_temp_dir()) . '/' . rand() . $this->_name . '.shm';
+        // Only use sys_get_temp_dir() if APP_TEMP_DIR is undefined
+        $this->_ipcSegFile = realpath(
+                rtrim(defined('APP_TEMP_DIR') ? APP_TEMP_DIR : sys_get_temp_dir(), '/')
+            )
+            . '/' . rand() . $this->_name . '.shm';
         touch($this->_ipcSegFile);
 
         $shmKey = ftok($this->_ipcSegFile, 't');


### PR DESCRIPTION
Restores the temp file changes originally introduced with PCR360-10433.
Temp files should once again only be created in /tmp when AP_TEMP_DIR is undefined

ZendX_Console_Process_Unix::_createIpcSegment will only use /tmp if APP_TEMP_DIR is undefined